### PR TITLE
chore: split release step into separate workflow

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -31,7 +31,7 @@ action "Install dependencies" {
 }
 
 action "Run tests" {
-  uses "actions/npm@master"
+  uses = "actions/npm@master"
   needs = ["Install dependencies"]
   args = "test"
 }

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -8,7 +8,6 @@ action "Update history files" {
   args = "run update"
   secrets = [
     "GH_TOKEN",
-    "NPM_AUTH_TOKEN",
   ]
 }
 

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,11 +1,45 @@
-workflow "Update and release" {
-  resolves = ["Update data and release"]
+workflow "Update data" {
+  resolves = ["Update history files"]
   on = "schedule(0 21 * * *)"
 }
 
-action "Update data and release" {
+action "Update history files" {
   uses = "actions/npm@master"
   args = "run update"
+  secrets = [
+    "GH_TOKEN",
+    "NPM_AUTH_TOKEN",
+  ]
+}
+
+
+workflow "Publish new release" {
+  resolves = "Publish via semantic-release"
+  on = "push"
+}
+
+action "Release master branch only" {
+  uses = "BinaryMuse/tip-of-branch@master"
+  args = "master"
+  secrets = ["GITHUB_TOKEN"]
+}
+
+action "Install dependencies" {
+  uses "actions/npm@master"
+  needs = "Release master branch only"
+  args = "ci"
+}
+
+action "Run tests" {
+  uses "actions/npm@master"
+  needs = ["Install dependencies"]
+  args = "test"
+}
+
+action "Publish via semantic-release" {
+  uses = "actions/npm@master"
+  needs = ["Run tests"]
+  args = "run semantic-release"
   secrets = [
     "GH_TOKEN",
     "NPM_AUTH_TOKEN",

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -26,7 +26,7 @@ action "Release master branch only" {
 
 action "Install dependencies" {
   uses = "actions/npm@master"
-  needs = "Release master branch only"
+  needs = ["Release master branch only"]
   args = "ci"
 }
 

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,6 +1,6 @@
 workflow "Update data" {
   resolves = ["Update history files"]
-  on = "schedule(0 21 * * *)"
+  on = "schedule(0 9 * * *)"
 }
 
 action "Update history files" {

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -25,7 +25,7 @@ action "Release master branch only" {
 }
 
 action "Install dependencies" {
-  uses "actions/npm@master"
+  uses = "actions/npm@master"
   needs = "Release master branch only"
   args = "ci"
 }

--- a/script/update.sh
+++ b/script/update.sh
@@ -38,4 +38,3 @@ npm test
 git add index.json
 git commit -am "feat: update history (electron@$ELECTRON_SHA)"
 git pull --rebase && git push
-npm run semantic-release


### PR DESCRIPTION
The current release workflow works except for the last step, `semantic-release`, which expects the current branch to be `master` but instead detects it as `undefined`. I did some cursory searching on how to disable this check, but came up empty-handed, so I decided to refactor the workflow so that commits to `master` trigger a deploy, similar to how the `i18n` workflows work. This has the added benefit of deploying when a PR with a matching commit message is merged.