### PR TITLE
ci: update GitHub workflows and update script

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -13,17 +13,17 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
+    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c  # tag: v3
+    - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c  # tag: v3
       with:
-        node-version: '12.x'
+        node-version: '16.x'
     - name: Install dependencies
-      run: npm ci
+      run: yarn install --frozen-lockfile
     - name: Run tests
-      run: npm test
+      run: yarn test
     - name: Publish via semantic-release
       if: github['ref'] == 'refs/heads/master'
       env:
         GH_TOKEN: ${{ secrets.GH_TOKEN }}
         NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
-      run: npm run semantic-release
+      run: yarn run semantic-release

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -9,11 +9,11 @@ jobs:
     name: Update history files
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
+    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c  # tag: v3
+    - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c  # tag: v3
       with:
-        node-version: '12.x'
+        node-version: '16.x'
     - name: Update history files
-      run: npm run update
+      run: yarn run update
       env:
         GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,7 @@
 # electron-api-historian 
 
+[![CI](https://github.com/electron/electron-api-historian/actions/workflows/push.yml/badge.svg)](https://github.com/electron/electron-api-historian/actions/workflows/push.yml)
+
 Find the birthday of every Electron API
 
 ## Installation
@@ -12,8 +14,8 @@ npm install electron-api-historian --save
 ## Tests
 
 ```sh
-npm install
-npm test
+yarn install
+yarn test
 ```
 
 ## Dependencies

--- a/script/update.sh
+++ b/script/update.sh
@@ -8,7 +8,7 @@ set -o nounset    # fail on unset variables
 git clone "https://electron-bot:$GH_TOKEN@github.com/electron/electron-api-historian" module
 cd module
 git submodule update --init
-npm ci
+yarn install --frozen-lockfile
 
 git config user.email electron@github.com
 git config user.name electron-bot
@@ -23,7 +23,7 @@ fi
 git add electron
 ELECTRON_SHA=$(git submodule status --cached electron | awk '{print $1}')
 
-npm run build
+yarn run build
 
 # bail if the data didn't change;
 # the build script will change the checked out submodule sha,
@@ -33,7 +33,7 @@ if [ "$(git status --porcelain -- index.json)" = "" ]; then
   exit 0
 fi
 
-npm test
+yarn test
 
 git add index.json
 git commit -am "feat: update history (electron@$ELECTRON_SHA)"


### PR DESCRIPTION
* Uses yarn after 9c6acb31297a9f8bbfbd7b3bbc0dacf259f80db1 dropped `package-lock.json`
* Uses Node v16
* Pins SHAs for actions
* Adds badge to readme